### PR TITLE
Add elasticsearch indexing support

### DIFF
--- a/exe/es_index.rb
+++ b/exe/es_index.rb
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+
+require "perseus"
+require "elasticsearch"
+
+host = ENV['ES_HOST'] || "localhost"
+port = ENV['ES_PORT'] || 9200
+ES_CONFIG = [{
+    host: host,
+      port: port
+}].freeze
+@es_client = Elasticsearch::Client.new hosts: ES_CONFIG
+@_index = "perseus-cts-by-edition"
+@_type = "edition"
+
+DESTRUCTIVE = true
+def extract_field field, string
+  match = "Perseus:bib:#{field},"
+  f = string[/#{match}\d+/]
+  unless f.nil?
+    f.gsub(match, "")
+  end
+end
+
+file = Perseus::ALL_EDITIONS_JSON
+json = JSON.parse(File.read(file))
+json.each do |doc|
+  _id = doc["urn"]
+  doc["collection"] = doc["memberof"]["collection"].gsub("Perseus:collection:", "")
+  doc["project"] = doc["projid"]
+  doc["group"] = doc["groupname"]
+  # extract some info from the description like oclc and isbn codes if they exist
+  description = doc["description"]
+  isbn = extract_field("isbn", description)
+  oclc = extract_field("oclc", description)
+  doc["isbn"] = isbn unless isbn.nil?
+  doc["oclc"] = oclc unless oclc.nil?
+  doc["edition"] = description.gsub(/Perseus:bib:isbn,\d+, /, "").gsub(/Perseus:bib:oclc,\d+, /, "")
+  if DESTRUCTIVE
+    doc.delete("online")
+    doc.delete("urn")
+    doc.delete("memberof")
+    doc.delete("projid")
+    doc.delete("groupname")
+    doc.delete("xml:lang")
+    doc.delete("description")
+  end
+  begin
+    @es_client.get(index: @_index, type:@_type, id:_id)
+    puts "Updating existing document: #{doc.inspect}"
+    @es_client.update(index: @_index, type:@_type, id:_id, body: { doc: doc })
+  rescue Elasticsearch::Transport::Transport::Errors::NotFound => not_found
+    #puts not_found.message
+    puts "Creating new document: #{doc.inspect}"
+    @es_client.create(index: @_index, type:@_type, id:_id, body: doc)
+    puts "Document indexed"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require "perseus"
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
[asana task](https://app.asana.com/0/525978251055599/525978251055621/f)

[issue](https://damos.fruitopology.net/agora/perseus/issues/2)

[merge request](https://damos.fruitopology.net/agora/perseus/merge_requests/1)

Allow the gem/tool to fetch the CTS database and index its works in elasticsearch

Some Screenshots of how this would look on elasticsearch:

<img width="1269" alt="perseus-ex-full-index" src="https://user-images.githubusercontent.com/3315682/44168475-6b957000-a09f-11e8-9239-bdbede5a83f6.png">

<img width="1265" alt="perseus-ex-homer-search" src="https://user-images.githubusercontent.com/3315682/44168476-6b957000-a09f-11e8-8cdd-7e23a5eeaeb1.png">